### PR TITLE
Accept split overrides via configOverrides API param

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,29 +4,49 @@ export interface ConfigOverrides {
 	optimism?: { markets?: number; safetyModule?: number; dex?: number; vaults?: number };
 }
 
-// Apply split overrides to mainConfig, returning a new config object
+// Apply split overrides to mainConfig, always returning a fresh deep copy
 export function applyConfigOverrides(overrides?: ConfigOverrides): typeof mainConfig {
-	if (!overrides) return mainConfig;
-
 	const config = JSON.parse(JSON.stringify(mainConfig));
-	if (overrides.moonbeam) {
-		if (overrides.moonbeam.markets !== undefined) config.moonbeam.markets = overrides.moonbeam.markets;
-		if (overrides.moonbeam.safetyModule !== undefined) config.moonbeam.safetyModule = overrides.moonbeam.safetyModule;
-		if (overrides.moonbeam.dex !== undefined) config.moonbeam.dex = overrides.moonbeam.dex;
-	}
-	if (overrides.base) {
-		if (overrides.base.markets !== undefined) config.base.markets = overrides.base.markets;
-		if (overrides.base.safetyModule !== undefined) config.base.safetyModule = overrides.base.safetyModule;
-		if (overrides.base.dex !== undefined) config.base.dex = overrides.base.dex;
-		if (overrides.base.vaults !== undefined) config.base.vaults = overrides.base.vaults;
-	}
-	if (overrides.optimism) {
-		if (overrides.optimism.markets !== undefined) config.optimism.markets = overrides.optimism.markets;
-		if (overrides.optimism.safetyModule !== undefined) config.optimism.safetyModule = overrides.optimism.safetyModule;
-		if (overrides.optimism.dex !== undefined) config.optimism.dex = overrides.optimism.dex;
-		if (overrides.optimism.vaults !== undefined) config.optimism.vaults = overrides.optimism.vaults;
-	}
+	if (!overrides) return config;
+
+	const applyNetworkOverrides = (
+		target: { markets: number; safetyModule: number; dex: number; vaults?: number },
+		source?: { markets?: number; safetyModule?: number; dex?: number; vaults?: number }
+	) => {
+		if (!source) return;
+		for (const [key, value] of Object.entries(source)) {
+			if (value !== undefined) {
+				if (typeof value !== 'number' || !isFinite(value)) {
+					throw new Error(`Invalid override: ${key} must be a finite number, got ${typeof value}`);
+				}
+				if (value < 0 || value > 1) {
+					throw new Error(`Invalid override: ${key} must be between 0 and 1, got ${value}`);
+				}
+				(target as any)[key] = value;
+			}
+		}
+	};
+
+	applyNetworkOverrides(config.moonbeam, overrides.moonbeam);
+	applyNetworkOverrides(config.base, overrides.base);
+	applyNetworkOverrides(config.optimism, overrides.optimism);
 	return config;
+}
+
+// Validate that splits for a network sum to approximately 1.0
+export function validateSplits(config: typeof mainConfig): string | null {
+	const networks: { name: string; sum: number }[] = [
+		{ name: 'moonbeam', sum: config.moonbeam.markets + config.moonbeam.safetyModule + config.moonbeam.dex },
+		{ name: 'base', sum: config.base.markets + config.base.safetyModule + config.base.dex + config.base.vaults },
+		{ name: 'optimism', sum: config.optimism.markets + config.optimism.safetyModule + config.optimism.dex + config.optimism.vaults },
+	];
+
+	for (const { name, sum } of networks) {
+		if (Math.abs(sum - 1.0) > 0.0001) {
+			return `${name} splits sum to ${(sum * 100).toFixed(2)}%, must be 100%`;
+		}
+	}
+	return null;
 }
 
 export const mainConfig = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,33 @@
+export interface ConfigOverrides {
+	moonbeam?: { markets?: number; safetyModule?: number; dex?: number };
+	base?: { markets?: number; safetyModule?: number; dex?: number; vaults?: number };
+	optimism?: { markets?: number; safetyModule?: number; dex?: number; vaults?: number };
+}
+
+// Apply split overrides to mainConfig, returning a new config object
+export function applyConfigOverrides(overrides?: ConfigOverrides): typeof mainConfig {
+	if (!overrides) return mainConfig;
+
+	const config = JSON.parse(JSON.stringify(mainConfig));
+	if (overrides.moonbeam) {
+		if (overrides.moonbeam.markets !== undefined) config.moonbeam.markets = overrides.moonbeam.markets;
+		if (overrides.moonbeam.safetyModule !== undefined) config.moonbeam.safetyModule = overrides.moonbeam.safetyModule;
+		if (overrides.moonbeam.dex !== undefined) config.moonbeam.dex = overrides.moonbeam.dex;
+	}
+	if (overrides.base) {
+		if (overrides.base.markets !== undefined) config.base.markets = overrides.base.markets;
+		if (overrides.base.safetyModule !== undefined) config.base.safetyModule = overrides.base.safetyModule;
+		if (overrides.base.dex !== undefined) config.base.dex = overrides.base.dex;
+		if (overrides.base.vaults !== undefined) config.base.vaults = overrides.base.vaults;
+	}
+	if (overrides.optimism) {
+		if (overrides.optimism.markets !== undefined) config.optimism.markets = overrides.optimism.markets;
+		if (overrides.optimism.safetyModule !== undefined) config.optimism.safetyModule = overrides.optimism.safetyModule;
+		if (overrides.optimism.dex !== undefined) config.optimism.dex = overrides.optimism.dex;
+		if (overrides.optimism.vaults !== undefined) config.optimism.vaults = overrides.optimism.vaults;
+	}
+	return config;
+}
 
 export const mainConfig = {
 	totalWellPerEpoch: 13_139_447.412450949,
@@ -65,6 +95,13 @@ export const mainConfig = {
 		periodMaxDiscount: 800000000000000000, // 20% discount from starting price
 		periodStartingPremium: 1200000000000000000, // 120% of current price
 	},
+};
+
+// Default split percentages per network, derived from mainConfig to stay in sync
+export const DEFAULT_SPLITS = {
+	moonbeam: { markets: mainConfig.moonbeam.markets, safetyModule: mainConfig.moonbeam.safetyModule, dex: mainConfig.moonbeam.dex },
+	base: { markets: mainConfig.base.markets, safetyModule: mainConfig.base.safetyModule, dex: mainConfig.base.dex, vaults: mainConfig.base.vaults },
+	optimism: { markets: mainConfig.optimism.markets, safetyModule: mainConfig.optimism.safetyModule, dex: mainConfig.optimism.dex, vaults: mainConfig.optimism.vaults },
 };
 
 export const merkleCampaignDatas = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { getMarketData } from "./markets";
 import { returnJson } from "./generateJson";
 import { generateMarkdown } from "./generateMarkdown";
 import { getDexInfo } from "./dex";
+import { applyConfigOverrides, validateSplits, type ConfigOverrides } from "./config";
 
 // Helper function to deep merge objects
 function deepMerge(target: any, source: any) {
@@ -48,13 +49,24 @@ export default {
 			return new Response('Missing required parameters: type and timestamp', { status: 400 });
 		}
 
-		// Parse config overrides if provided (URL-encoded JSON)
-		let configOverrides: import('./config').ConfigOverrides | undefined;
+		// Parse and validate config overrides if provided (URL-encoded JSON)
+		let configOverrides: ConfigOverrides | undefined;
 		if (configOverridesParam) {
 			try {
 				configOverrides = JSON.parse(configOverridesParam);
 			} catch {
 				return new Response('Invalid configOverrides JSON', { status: 400 });
+			}
+
+			// Validate override values and split sums
+			try {
+				const effectiveConfig = applyConfigOverrides(configOverrides);
+				const validationError = validateSplits(effectiveConfig);
+				if (validationError) {
+					return new Response(`Invalid config overrides: ${validationError}`, { status: 400 });
+				}
+			} catch (e) {
+				return new Response(`Invalid config overrides: ${e instanceof Error ? e.message : String(e)}`, { status: 400 });
 			}
 		}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,14 +42,25 @@ export default {
 		const type = searchParams.get('type');
 		const network = searchParams.get('network');
 		const timestamp = searchParams.get('timestamp');
+		const configOverridesParam = searchParams.get('configOverrides');
 
 		if (!type || !timestamp) {
 			return new Response('Missing required parameters: type and timestamp', { status: 400 });
 		}
 
+		// Parse config overrides if provided (URL-encoded JSON)
+		let configOverrides: import('./config').ConfigOverrides | undefined;
+		if (configOverridesParam) {
+			try {
+				configOverrides = JSON.parse(configOverridesParam);
+			} catch {
+				return new Response('Invalid configOverrides JSON', { status: 400 });
+			}
+		}
+
 		try {
 			if (type === 'json') {
-				const marketData = await getMarketData(Number(timestamp), env);
+				const marketData = await getMarketData(Number(timestamp), env, configOverrides);
 				let json = '';
 				const networks = network ? [network] : ['Base', 'Optimism', 'Moonbeam'];
 
@@ -66,7 +77,7 @@ export default {
 				});
 			} else if (type === 'markdown') {
 				const proposalNumber = searchParams.get('proposal') || 'X??';
-				const marketData = await getMarketData(Number(timestamp), env);
+				const marketData = await getMarketData(Number(timestamp), env, configOverrides);
 				const dexData = await getDexInfo();
 				let markdown = '';
 				if (network) {

--- a/src/markets.ts
+++ b/src/markets.ts
@@ -1,5 +1,5 @@
 import { formatUnits } from "viem";
-import { mainConfig, marketConfigs } from "./config";
+import { marketConfigs, applyConfigOverrides, type ConfigOverrides } from "./config";
 import { getSafetyModuleDataForAllChains } from "./safetyModule";
 import { ContractCall, createClients, baseClient as defaultBaseClient, moonbeamClient as defaultMoonbeamClient, optimismClient as defaultOptimismClient } from "./utils";
 
@@ -185,7 +185,10 @@ async function getOptimismMarkets() {
   return await filterExcludedMarkets(markets as string[], 10);
 }
 
-export async function getMarketData(timestamp: number, env?: any) {
+export async function getMarketData(timestamp: number, env?: any, configOverrides?: ConfigOverrides) {
+  // Apply config overrides to get effective config for this request
+  const config = applyConfigOverrides(configOverrides);
+
   // If environment variables are provided, create clients with them
   if (env) {
     const clients = createClients(env);
@@ -1130,10 +1133,10 @@ export async function getMarketData(timestamp: number, env?: any) {
   );
 
   const calculateEpochStartTimestamp = () => {
-    let epochStartTimestamp = mainConfig.firstEpochTimestamp;
+    let epochStartTimestamp = config.firstEpochTimestamp;
 
-    while (timestamp >= epochStartTimestamp + mainConfig.secondsPerEpoch) {
-      epochStartTimestamp += mainConfig.secondsPerEpoch;
+    while (timestamp >= epochStartTimestamp + config.secondsPerEpoch) {
+      epochStartTimestamp += config.secondsPerEpoch;
     }
 
     return epochStartTimestamp;
@@ -1146,12 +1149,12 @@ export async function getMarketData(timestamp: number, env?: any) {
       return currentSpeed === 0 ? currentSpeed : 0;
     }
     const totalWellPerEpochMarkets =
-      mainConfig.totalWellPerEpoch
+      config.totalWellPerEpoch
       * moonbeamTotalMarketPercentage
-      * mainConfig.moonbeam.markets;
+      * config.moonbeam.markets;
     const percentage = moonbeamPercentages[index];
     const supplyRatio = moonbeamSupplyRatios[index] ?? 0;
-    const calculatedSpeed = Number((totalWellPerEpochMarkets * percentage * supplyRatio) / mainConfig.secondsPerEpoch);
+    const calculatedSpeed = Number((totalWellPerEpochMarkets * percentage * supplyRatio) / config.secondsPerEpoch);
 
     // Return currentSpeed if the speeds are the same, otherwise return the calculated speed
     return Math.abs(calculatedSpeed - currentSpeed) < 1e-18 ? currentSpeed : calculatedSpeed;
@@ -1164,12 +1167,12 @@ export async function getMarketData(timestamp: number, env?: any) {
       return currentSpeed === 1e-18 ? currentSpeed : 1e-18;
     }
     const totalWellPerEpochMarkets =
-      mainConfig.totalWellPerEpoch
+      config.totalWellPerEpoch
       * moonbeamTotalMarketPercentage
-      * mainConfig.moonbeam.markets;
+      * config.moonbeam.markets;
     const percentage = moonbeamPercentages[index];
     const borrowRatio = moonbeamBorrowRatios[index] ?? 0;
-    const calculatedSpeed = Number((totalWellPerEpochMarkets * percentage * borrowRatio) / mainConfig.secondsPerEpoch);
+    const calculatedSpeed = Number((totalWellPerEpochMarkets * percentage * borrowRatio) / config.secondsPerEpoch);
     // Return currentSpeed if the speeds are the same
     if (Math.abs(calculatedSpeed - currentSpeed) < 1e-18) {
       return currentSpeed;
@@ -1186,12 +1189,12 @@ export async function getMarketData(timestamp: number, env?: any) {
       return currentSpeed === 0 ? -1e-18 : 0;
     }
     const totalWellPerEpochMarkets =
-      mainConfig.totalWellPerEpoch
+      config.totalWellPerEpoch
       * baseTotalMarketPercentage
-      * mainConfig.base.markets;
+      * config.base.markets;
     const percentage = basePercentages[index];
     const supplyRatio = baseSupplyRatios[index] ?? 0;
-    const calculatedSpeed = Number((totalWellPerEpochMarkets * percentage * supplyRatio) / mainConfig.secondsPerEpoch);
+    const calculatedSpeed = Number((totalWellPerEpochMarkets * percentage * supplyRatio) / config.secondsPerEpoch);
 
     // Return -1 if the speeds are the same, otherwise return the calculated speed
     return Math.abs(calculatedSpeed - currentSpeed) < 1e-18 ? -1e-18 : calculatedSpeed;
@@ -1204,12 +1207,12 @@ export async function getMarketData(timestamp: number, env?: any) {
       return currentSpeed === 1e-18 ? -1e-18: 1e-18;
     }
     const totalWellPerEpochMarkets =
-      mainConfig.totalWellPerEpoch
+      config.totalWellPerEpoch
       * baseTotalMarketPercentage
-      * mainConfig.base.markets;
+      * config.base.markets;
     const percentage = basePercentages[index];
     const borrowRatio = baseBorrowRatios[index] ?? 0;
-    const calculatedSpeed = Number((totalWellPerEpochMarkets * percentage * borrowRatio) / mainConfig.secondsPerEpoch);
+    const calculatedSpeed = Number((totalWellPerEpochMarkets * percentage * borrowRatio) / config.secondsPerEpoch);
     // Return -1e-18 if the current speed is 1e-18 and the calculated speed is 0
     if (currentSpeed === 1e-18 && calculatedSpeed === 0) {
       return -1e-18;
@@ -1231,12 +1234,12 @@ export async function getMarketData(timestamp: number, env?: any) {
       return currentSpeed === 0 ? -1e-18: 0;
     }
     const totalWellPerEpochMarkets =
-      mainConfig.totalWellPerEpoch
+      config.totalWellPerEpoch
       * optimismTotalMarketPercentage
-      * mainConfig.optimism.markets;
+      * config.optimism.markets;
     const percentage = optimismPercentages[index];
     const supplyRatio = optimismSupplyRatios[index] ?? 0;
-    const calculatedSpeed = Number((totalWellPerEpochMarkets * percentage * supplyRatio) / mainConfig.secondsPerEpoch);
+    const calculatedSpeed = Number((totalWellPerEpochMarkets * percentage * supplyRatio) / config.secondsPerEpoch);
 
     // Return -1 if the speeds are the same, otherwise return the calculated speed
     return Math.abs(calculatedSpeed - currentSpeed) < 1e-18 ? -1e-18 : calculatedSpeed;
@@ -1250,12 +1253,12 @@ export async function getMarketData(timestamp: number, env?: any) {
     }
 
     const totalWellPerEpochMarkets =
-      mainConfig.totalWellPerEpoch
+      config.totalWellPerEpoch
       * optimismTotalMarketPercentage
-      * mainConfig.optimism.markets;
+      * config.optimism.markets;
     const percentage = optimismPercentages[index];
     const borrowRatio = optimismBorrowRatios[index] ?? 0;
-    const calculatedSpeed = Number((totalWellPerEpochMarkets * percentage * borrowRatio) / mainConfig.secondsPerEpoch);
+    const calculatedSpeed = Number((totalWellPerEpochMarkets * percentage * borrowRatio) / config.secondsPerEpoch);
     // Return -1e-18 if the current speed is 1e-18 and the calculated speed is 0
     if (currentSpeed === 1e-18 && calculatedSpeed === 0) {
       return -1e-18;
@@ -1275,10 +1278,10 @@ export async function getMarketData(timestamp: number, env?: any) {
     if (!moonbeamEnabled[index]) { // Only include markets that are enabled
       return currentSpeed === 0 ? currentSpeed : 0;
     }
-    const totalNativePerEpochMarkets = mainConfig.moonbeam.nativePerEpoch;
+    const totalNativePerEpochMarkets = config.moonbeam.nativePerEpoch;
     const percentage = moonbeamPercentages[index];
     const supplyRatio = moonbeamSupplyRatios[index] ?? 0;
-    const calculatedSpeed = Number((totalNativePerEpochMarkets * percentage * supplyRatio) / mainConfig.secondsPerEpoch);
+    const calculatedSpeed = Number((totalNativePerEpochMarkets * percentage * supplyRatio) / config.secondsPerEpoch);
 
     // Return currentSpeed if the speeds are the same, otherwise return the calculated speed
     return Math.abs(calculatedSpeed - currentSpeed) < 1e-18 ? currentSpeed : calculatedSpeed;
@@ -1290,10 +1293,10 @@ export async function getMarketData(timestamp: number, env?: any) {
     if (!moonbeamEnabled[index]) { // Only include markets that are enabled
       return currentSpeed === 1e-18 ? currentSpeed : 1e-18;
     }
-    const totalNativePerEpochMarkets = mainConfig.moonbeam.nativePerEpoch;
+    const totalNativePerEpochMarkets = config.moonbeam.nativePerEpoch;
     const percentage = moonbeamPercentages[index];
     const borrowRatio = moonbeamBorrowRatios[index] ?? 0;
-    const calculatedSpeed = Number((totalNativePerEpochMarkets * percentage * borrowRatio) / mainConfig.secondsPerEpoch);
+    const calculatedSpeed = Number((totalNativePerEpochMarkets * percentage * borrowRatio) / config.secondsPerEpoch);
 
     // Return currentSpeed if the speeds are the same
     if (Math.abs(calculatedSpeed - currentSpeed) < 1e-18) {
@@ -1316,10 +1319,10 @@ export async function getMarketData(timestamp: number, env?: any) {
       return currentSpeed === 0 ? -1e-6 : 0;
     }
 
-    const totalNativePerEpochMarkets = mainConfig.base.nativePerEpoch;
+    const totalNativePerEpochMarkets = config.base.nativePerEpoch;
     const percentage = basePercentages[index];
     const supplyRatio = baseSupplyRatios[index] ?? 0;
-    const calculatedSpeed = Number((totalNativePerEpochMarkets * percentage * supplyRatio) / mainConfig.secondsPerEpoch);
+    const calculatedSpeed = Number((totalNativePerEpochMarkets * percentage * supplyRatio) / config.secondsPerEpoch);
 
     // Return -1 if the speeds are the same, otherwise return the calculated speed
     return Math.abs(calculatedSpeed - currentSpeed) < 1e-6 ? -1e-6 : calculatedSpeed;
@@ -1337,10 +1340,10 @@ export async function getMarketData(timestamp: number, env?: any) {
       return currentSpeed === 1e-6 ? -1e-6 : 1e-6;
     }
 
-    const totalNativePerEpochMarkets = mainConfig.base.nativePerEpoch;
+    const totalNativePerEpochMarkets = config.base.nativePerEpoch;
     const percentage = basePercentages[index];
     const borrowRatio = baseBorrowRatios[index] ?? 0;
-    const calculatedSpeed = Number((totalNativePerEpochMarkets * percentage * borrowRatio) / mainConfig.secondsPerEpoch);
+    const calculatedSpeed = Number((totalNativePerEpochMarkets * percentage * borrowRatio) / config.secondsPerEpoch);
 
     // Return -1 if the speeds are the same
     if ((calculatedSpeed === 0) && (currentSpeed === 0.000001)) {
@@ -1358,10 +1361,10 @@ export async function getMarketData(timestamp: number, env?: any) {
       return currentSpeed === 0 ? -1e-18 : 0;
     }
 
-    const totalNativePerEpochMarkets = mainConfig.optimism.nativePerEpoch;
+    const totalNativePerEpochMarkets = config.optimism.nativePerEpoch;
     const percentage = optimismPercentages[index];
     const supplyRatio = optimismSupplyRatios[index] ?? 0;
-    const calculatedSpeed = Number((totalNativePerEpochMarkets * percentage * supplyRatio) / mainConfig.secondsPerEpoch);
+    const calculatedSpeed = Number((totalNativePerEpochMarkets * percentage * supplyRatio) / config.secondsPerEpoch);
 
     // Return -1 if the speeds are the same, otherwise return the calculated speed
     return Math.abs(calculatedSpeed - currentSpeed) < 1e-18 ? -1e-18 : calculatedSpeed;
@@ -1374,10 +1377,10 @@ export async function getMarketData(timestamp: number, env?: any) {
       return currentSpeed === 1e-18 ? -1e-18 : 1e-18;
     }
 
-    const totalNativePerEpochMarkets = mainConfig.optimism.nativePerEpoch;
+    const totalNativePerEpochMarkets = config.optimism.nativePerEpoch;
     const percentage = optimismPercentages[index];
     const borrowRatio = optimismBorrowRatios[index] ?? 0;
-    const calculatedSpeed = Number((totalNativePerEpochMarkets * percentage * borrowRatio) / mainConfig.secondsPerEpoch);
+    const calculatedSpeed = Number((totalNativePerEpochMarkets * percentage * borrowRatio) / config.secondsPerEpoch);
 
     // Return -1e-18 if the current speed is 1e-18 and the calculated speed is 0
     if (currentSpeed === 1e-18 && calculatedSpeed === 0) {
@@ -1732,31 +1735,31 @@ export async function getMarketData(timestamp: number, env?: any) {
 
   const [wethVaultTotalAssets, usdcVaultTotalAssets, eurcVaultTotalAssets, cbBTCVaultTotalAssets, meUSDCVaultTotalAssets] = await Promise.all([
     baseClient.readContract({
-      address: mainConfig.base.vaultAddresses.WETH,
+      address: config.base.vaultAddresses.WETH,
       abi: erc4626TotalAssetsAbi,
       functionName: "totalAssets",
       blockNumber: BigInt(baseBlockNumber),
     }) as Promise<bigint>,
     baseClient.readContract({
-      address: mainConfig.base.vaultAddresses.USDC,
+      address: config.base.vaultAddresses.USDC,
       abi: erc4626TotalAssetsAbi,
       functionName: "totalAssets",
       blockNumber: BigInt(baseBlockNumber),
     }) as Promise<bigint>,
     baseClient.readContract({
-      address: mainConfig.base.vaultAddresses.EURC,
+      address: config.base.vaultAddresses.EURC,
       abi: erc4626TotalAssetsAbi,
       functionName: "totalAssets",
       blockNumber: BigInt(baseBlockNumber),
     }) as Promise<bigint>,
     baseClient.readContract({
-      address: mainConfig.base.vaultAddresses.cbBTC,
+      address: config.base.vaultAddresses.cbBTC,
       abi: erc4626TotalAssetsAbi,
       functionName: "totalAssets",
       blockNumber: BigInt(baseBlockNumber),
     }) as Promise<bigint>,
     baseClient.readContract({
-      address: mainConfig.base.vaultAddresses.meUSDC,
+      address: config.base.vaultAddresses.meUSDC,
       abi: erc4626TotalAssetsAbi,
       functionName: "totalAssets",
       blockNumber: BigInt(baseBlockNumber),
@@ -1835,14 +1838,14 @@ export async function getMarketData(timestamp: number, env?: any) {
       optimismNativeSupplyPerDayUsd,
       optimismNativeBorrowPerDayUsd,
       optimismPercentages,
-      Number((mainConfig.totalWellPerEpoch * optimismTotalMarketPercentage) * mainConfig.optimism.markets),
+      Number((config.totalWellPerEpoch * optimismTotalMarketPercentage) * config.optimism.markets),
       optimismNewWellSupplySpeeds,
       optimismNewWellBorrowSpeeds,
       optimismNewNativeSupplySpeeds,
       optimismNewNativeBorrowSpeeds,
       formatUnits(wellPrice, 36),
       optimismNativePrice,
-      Number(mainConfig.optimism.nativePerEpoch),
+      Number(config.optimism.nativePerEpoch),
     ),
     1284: formatResults(
       moonbeamMarkets,
@@ -1877,14 +1880,14 @@ export async function getMarketData(timestamp: number, env?: any) {
       moonbeamNativeSupplyPerDayUsd,
       moonbeamNativeBorrowPerDayUsd,
       moonbeamPercentages,
-      Number((mainConfig.totalWellPerEpoch * moonbeamTotalMarketPercentage) * mainConfig.moonbeam.markets),
+      Number((config.totalWellPerEpoch * moonbeamTotalMarketPercentage) * config.moonbeam.markets),
       moonbeamNewWellSupplySpeeds,
       moonbeamNewWellBorrowSpeeds,
       moonbeamNewNativeSupplySpeeds,
       moonbeamNewNativeBorrowSpeeds,
       formatUnits(wellPrice, 36),
       moonbeamNativePrice,
-      Number(mainConfig.moonbeam.nativePerEpoch),
+      Number(config.moonbeam.nativePerEpoch),
     ),
     8453: formatResults(
       baseMarkets,
@@ -1919,52 +1922,52 @@ export async function getMarketData(timestamp: number, env?: any) {
       baseNativeSupplyPerDayUsd,
       baseNativeBorrowPerDayUsd,
       basePercentages,
-      Number((mainConfig.totalWellPerEpoch * baseTotalMarketPercentage) * mainConfig.base.markets),
+      Number((config.totalWellPerEpoch * baseTotalMarketPercentage) * config.base.markets),
       baseNewWellSupplySpeeds,
       baseNewWellBorrowSpeeds,
       baseNewNativeSupplySpeeds,
       baseNewNativeBorrowSpeeds,
       formatUnits(wellPrice, 36),
       baseNativePrice,
-      Number(mainConfig.base.nativePerEpoch),
+      Number(config.base.nativePerEpoch),
     ),
     wellPrice: formatUnits(wellPrice, 36),
     glmrPrice: moonbeamNativePrice,
     usdcPrice: baseNativePrice,
     opPrice: optimismNativePrice,
-    epochStartTimestamp: calculateEpochStartTimestamp() + mainConfig.secondsPerEpoch,
-    epochEndTimestamp: calculateEpochStartTimestamp() + mainConfig.secondsPerEpoch * 2,
-    totalSeconds: mainConfig.secondsPerEpoch,
-    wellPerEpoch: mainConfig.totalWellPerEpoch,
+    epochStartTimestamp: calculateEpochStartTimestamp() + config.secondsPerEpoch,
+    epochEndTimestamp: calculateEpochStartTimestamp() + config.secondsPerEpoch * 2,
+    totalSeconds: config.secondsPerEpoch,
+    wellPerEpoch: config.totalWellPerEpoch,
     bridgeCost: (await getBridgeCost()).toString(),
     timestamp: timestamp,
     moonbeamBlockNumber: moonbeamBlockNumber,
     baseBlockNumber: baseBlockNumber,
     optimismBlockNumber: optimismBlockNumber,
     moonbeam: {
-      ...mainConfig.moonbeam,
+      ...config.moonbeam,
       networkTotalUsd: moonbeamNetworkTotalUsd,
       totalMarketPercentage: moonbeamTotalMarketPercentage,
-      wellPerEpoch: Number(mainConfig.totalWellPerEpoch * moonbeamTotalMarketPercentage).toFixed(18),
-      nativePerEpoch: mainConfig.moonbeam.nativePerEpoch,
-      wellPerEpochMarkets: Number((mainConfig.totalWellPerEpoch * moonbeamTotalMarketPercentage) * mainConfig.moonbeam.markets).toFixed(18),
-      wellPerEpochSafetyModule: Number((mainConfig.totalWellPerEpoch * moonbeamTotalMarketPercentage) * mainConfig.moonbeam.safetyModule).toFixed(18),
-      wellPerEpochDex: Number((mainConfig.totalWellPerEpoch * moonbeamTotalMarketPercentage) * mainConfig.moonbeam.dex).toFixed(18),
+      wellPerEpoch: Number(config.totalWellPerEpoch * moonbeamTotalMarketPercentage).toFixed(18),
+      nativePerEpoch: config.moonbeam.nativePerEpoch,
+      wellPerEpochMarkets: Number((config.totalWellPerEpoch * moonbeamTotalMarketPercentage) * config.moonbeam.markets).toFixed(18),
+      wellPerEpochSafetyModule: Number((config.totalWellPerEpoch * moonbeamTotalMarketPercentage) * config.moonbeam.safetyModule).toFixed(18),
+      wellPerEpochDex: Number((config.totalWellPerEpoch * moonbeamTotalMarketPercentage) * config.moonbeam.dex).toFixed(18),
     },
     base: {
-      ...mainConfig.base,
+      ...config.base,
       networkTotalUsd: baseNetworkTotalUsd,
       totalMarketPercentage: baseTotalMarketPercentage,
-      wellPerEpoch: Number(mainConfig.totalWellPerEpoch * baseTotalMarketPercentage).toFixed(18),
-      nativePerEpoch: mainConfig.base.nativePerEpoch,
-      wellPerEpochMarkets: Number((mainConfig.totalWellPerEpoch * baseTotalMarketPercentage) * mainConfig.base.markets).toFixed(18),
-      wellPerEpochSafetyModule: Number(((mainConfig.totalWellPerEpoch) * baseTotalMarketPercentage) * mainConfig.base.safetyModule).toFixed(18),
-      wellPerEpochDex: Number((mainConfig.totalWellPerEpoch * baseTotalMarketPercentage) * mainConfig.base.dex).toFixed(18),
+      wellPerEpoch: Number(config.totalWellPerEpoch * baseTotalMarketPercentage).toFixed(18),
+      nativePerEpoch: config.base.nativePerEpoch,
+      wellPerEpochMarkets: Number((config.totalWellPerEpoch * baseTotalMarketPercentage) * config.base.markets).toFixed(18),
+      wellPerEpochSafetyModule: Number(((config.totalWellPerEpoch) * baseTotalMarketPercentage) * config.base.safetyModule).toFixed(18),
+      wellPerEpochDex: Number((config.totalWellPerEpoch * baseTotalMarketPercentage) * config.base.dex).toFixed(18),
       wellHolderBalance: baseWellHolderBalance.toString(),
-      wellPerEpochVaults: Number((mainConfig.totalWellPerEpoch * baseTotalMarketPercentage) * mainConfig.base.vaults).toFixed(18),
+      wellPerEpochVaults: Number((config.totalWellPerEpoch * baseTotalMarketPercentage) * config.base.vaults).toFixed(18),
       vaultAmounts: (() => {
         // Calculate total WELL allocation for vaults
-        const totalVaultWELL = (mainConfig.totalWellPerEpoch * baseTotalMarketPercentage) * mainConfig.base.vaults;
+        const totalVaultWELL = (config.totalWellPerEpoch * baseTotalMarketPercentage) * config.base.vaults;
 
         // Calculate USD TVL for each vault
         // Oracle returns prices in (36 - underlyingDecimals) format
@@ -1982,11 +1985,11 @@ export async function getMarketData(timestamp: number, env?: any) {
         const meUSDCTVL_USD = Number(formatUnits(meUSDCVaultTotalAssets, 6)); // meUSDC = $1
 
         // Apply weight multipliers from config (2.0x for stablecoins, 1.0x for others)
-        const wethWeighted = wethTVL_USD * mainConfig.base.vaultWeightMultipliers.WETH;
-        const usdcWeighted = usdcTVL_USD * mainConfig.base.vaultWeightMultipliers.USDC;
-        const eurcWeighted = eurcTVL_USD * mainConfig.base.vaultWeightMultipliers.EURC;
-        const cbBTCWeighted = cbBTCTVL_USD * mainConfig.base.vaultWeightMultipliers.cbBTC;
-        const meUSDCWeighted = meUSDCTVL_USD * mainConfig.base.vaultWeightMultipliers.meUSDC;
+        const wethWeighted = wethTVL_USD * config.base.vaultWeightMultipliers.WETH;
+        const usdcWeighted = usdcTVL_USD * config.base.vaultWeightMultipliers.USDC;
+        const eurcWeighted = eurcTVL_USD * config.base.vaultWeightMultipliers.EURC;
+        const cbBTCWeighted = cbBTCTVL_USD * config.base.vaultWeightMultipliers.cbBTC;
+        const meUSDCWeighted = meUSDCTVL_USD * config.base.vaultWeightMultipliers.meUSDC;
 
         // Calculate total weighted TVL
         const totalWeighted = wethWeighted + usdcWeighted + eurcWeighted + cbBTCWeighted + meUSDCWeighted;
@@ -2002,16 +2005,16 @@ export async function getMarketData(timestamp: number, env?: any) {
       })(),
     },
     optimism: {
-      ...mainConfig.optimism,
+      ...config.optimism,
       networkTotalUsd: optimismNetworkTotalUsd,
       totalMarketPercentage: optimismTotalMarketPercentage,
-      wellPerEpoch: Number(mainConfig.totalWellPerEpoch * optimismTotalMarketPercentage).toFixed(18),
-      nativePerEpoch: mainConfig.optimism.nativePerEpoch,
-      wellPerEpochMarkets: Number((mainConfig.totalWellPerEpoch * optimismTotalMarketPercentage) * mainConfig.optimism.markets).toFixed(18),
-      wellPerEpochSafetyModule: Number(((mainConfig.totalWellPerEpoch) * optimismTotalMarketPercentage) * mainConfig.optimism.safetyModule).toFixed(18),
-      wellPerEpochDex: Number((mainConfig.totalWellPerEpoch * optimismTotalMarketPercentage) * mainConfig.optimism.dex).toFixed(18),
+      wellPerEpoch: Number(config.totalWellPerEpoch * optimismTotalMarketPercentage).toFixed(18),
+      nativePerEpoch: config.optimism.nativePerEpoch,
+      wellPerEpochMarkets: Number((config.totalWellPerEpoch * optimismTotalMarketPercentage) * config.optimism.markets).toFixed(18),
+      wellPerEpochSafetyModule: Number(((config.totalWellPerEpoch) * optimismTotalMarketPercentage) * config.optimism.safetyModule).toFixed(18),
+      wellPerEpochDex: Number((config.totalWellPerEpoch * optimismTotalMarketPercentage) * config.optimism.dex).toFixed(18),
       wellHolderBalance: optimismWellHolderBalance.toString(),
-      optimismUSDCVaultWellRewardAmount: Number((mainConfig.totalWellPerEpoch * optimismTotalMarketPercentage) * mainConfig.optimism.vaults),
+      optimismUSDCVaultWellRewardAmount: Number((config.totalWellPerEpoch * optimismTotalMarketPercentage) * config.optimism.vaults),
     },
     safetyModule: safetyModuleData,
     baseStkWELLTotalSupply: baseStkWELLTotalSupply.toString(),


### PR DESCRIPTION
## Summary
- Adds `configOverrides` query parameter to the reward automation API (URL-encoded JSON)
- Exports `DEFAULT_SPLITS` derived from `mainConfig` so external consumers stay in sync
- `applyConfigOverrides()` creates a deep copy of `mainConfig` and merges overrides (safe for concurrent requests)
- All `mainConfig` split references in `markets.ts` now use the effective config

## API Usage
```
GET /?type=json&timestamp=...&configOverrides={"base":{"markets":0.60,"safetyModule":0.15,"dex":0.0,"vaults":0.25}}
```

## Test plan
- [ ] Call API without `configOverrides` — verify output matches current behavior
- [ ] Call API with `configOverrides` for Base — verify split percentages are applied
- [ ] Call API with invalid JSON — verify 400 error
- [ ] Verify no shared state between concurrent requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)