### PR TITLE
Remove GLMR rewards from Moonbeam

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -60,7 +60,7 @@ export const mainConfig = {
 	firstEpochTimestamp: 1757683818,
 	secondsPerEpoch: 60 * 60 * 24 * 7 * 4, // 4 weeks
 	moonbeam: {
-		nativePerEpoch: 187_500, // 1,125,000 GLMR / 6 months (extra 2 weeks from Dec. 1 to Dec. 14th to fund out of treasury)
+		nativePerEpoch: 0, // GLMR grant fully spent, no more GLMR rewards
 		markets: 0.48,
 		safetyModule: 0.47,
 		dex: 0.05,


### PR DESCRIPTION
## Summary
- Set `mainConfig.moonbeam.nativePerEpoch` from `187_500` to `0` — the GLMR grant is fully spent, so no more GLMR should be distributed to Moonbeam markets.

## How it works
- `markets.ts` reads `config.moonbeam.nativePerEpoch` and multiplies it through to compute per-market GLMR supply/borrow speeds. With `0`, all downstream GLMR speeds zero out.
- `generateMarkdown.ts` already guards every GLMR row with `if (Number(networkMarketData?.nativePerEpoch) !== 0)` — GLMR rows will be hidden from proposals automatically (same behavior Base and Optimism already have with `nativePerEpoch: 0`).
- `generateJson.ts` will emit `setRewardSpeed` calls with `rewardType: 1` (GLMR) at zero supply/borrow speeds — correctly zeroing prior on-chain GLMR speeds. WELL (GOVTOKEN) transfers are untouched.
- No GLMR-specific transfer transactions to remove — the F-GLMR-LM multisig only transfers WELL.

## Test plan
- [ ] Run `npm test` locally
- [ ] Generate a JSON output for a Moonbeam-only timestamp and confirm GLMR `setRewardSpeed` entries are all zero
- [ ] Generate a markdown output and confirm no GLMR APR rows appear for Moonbeam markets