### PR TITLE
fix(optimism): zero stkWellEmissionsPerSecond while rewards are wound down

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -139,9 +139,10 @@ export const mainConfig = {
     5. 50,000 in August for core markets and 10,000 for the USDC vault */
 		// OPTIMISM WIND-DOWN: rewardsEnabled false treats Optimism TVL as 0 in the cross-network
 		// WELL split, so Base/Ethereum absorb its share and Optimism markets get zero-speed
-		// wind-down actions. stkWELL auction recycling (wellHolderBalance) is independent of
-		// this flag and keeps emitting. To RE-ENABLE: set `rewardsEnabled: true` (splits below
-		// already sum to 1.0).
+		// wind-down actions. The safety module winds down with it: generateJson emits
+		// stkWellEmissionsPerSecond 0 for chain 10 while this flag is false, so stkWELL auction
+		// recycling (wellHolderBalance) no longer leaks a dust emission rate. To RE-ENABLE: set
+		// `rewardsEnabled: true` (splits below already sum to 1.0).
 		rewardsEnabled: false,
 		nativePerEpoch: 0,
 		rewarderNames: ['USDC_MULTI_REWARDER'], // Names of multi-rewarders to distribute rewards to

--- a/src/generateJson.ts
+++ b/src/generateJson.ts
@@ -484,6 +484,20 @@ export async function returnJson(marketData: any, network: string) {
         } : {}),
         setMRDSpeeds: optimismSetRewardSpeeds,
         stkWellEmissionsPerSecond: (() => {
+          // OPTIMISM WIND-DOWN: safety-module incentives are deprecated, so emit a
+          // flat 0. Without this, stkWELL auction recycling (wellHolderBalance)
+          // keeps producing a dust rate even though the safetyModule split is 0 —
+          // e.g. 373357228 wei/s (~0.001 WELL over a 31-day epoch), which puts a
+          // pointless configureAssets action on Optimism every epoch.
+          //
+          // The key stays present rather than being omitted: the proposal template
+          // parses `.10.stkWellEmissionsPerSecond` unconditionally and reverts on a
+          // missing path. A 0 is what it wants — both the build and validate paths
+          // guard on `> 0`, so a zero emits no action and asserts nothing.
+          //
+          // Re-enabling `optimism.rewardsEnabled` restores the computed rate.
+          if (!mainConfig.optimism.rewardsEnabled) return 0;
+
           const safetyModuleRewards = parseFloat(marketData.optimism.wellPerEpochSafetyModule);
           const { cappedBalance } = calculateCappedWellHolderBalance(
             safetyModuleRewards,


### PR DESCRIPTION
## Problem

Chain 10 emits a dust safety-module rate every epoch even though Optimism incentives are wound down.

The `optimism.safetyModule` split is `0`, but `stkWellEmissionsPerSecond` was computed from `safetyModuleRewards + cappedBalance`, and `cappedBalance` comes from stkWELL auction recycling (`wellHolderBalance`) — which was wired independently of `optimism.rewardsEnabled`. The config comment said so out loud:

> stkWELL auction recycling (wellHolderBalance) is independent of this flag and keeps emitting.

Result in the current epoch's output (`?timestamp=1786138600`, 2026-08-15 -> 2026-09-15):

```json
"10": {
  "stkWellEmissionsPerSecond": 373357228,
  "transferFrom": [],
  "withdrawWell": []
}
```

373,357,228 wei/s is about **0.001 WELL over a 31-day epoch**. Two consequences:

1. Every rewards MIP carries a pointless `configureAssets` action on Optimism.
2. The proposal template's coupling check degenerates to `assertApproxEqRel(0, 1e15, 1e18)` — a 100% tolerance against zero, which passes trivially. The assertion looks like coverage but provides none for this branch.

Exposure is dust and has been identical since MIP-X62, so this was never blocking — it is a correctness and signal-quality fix.

## Change

`generateJson.ts` returns a flat `0` for chain 10 while `optimism.rewardsEnabled` is `false`. Re-enabling the flag restores the computed rate, auction recycling included.

The key is still emitted rather than omitted. `RewardsDistributionV2Template._saveExternalChainActions` calls `_saveStkWellEmissionsPerSecond` for every chain that is not Base or Ethereum, and that does a bare `vm.parseJsonUint` on `.10.stkWellEmissionsPerSecond` — a missing path reverts the whole proposal parse. `0` is the value the template is built to absorb: both `_buildExternalChainActions` and the validate path guard on `> 0`, so a zero pushes no action and asserts nothing.

The stale config comment is updated to match.

## Not changed, on purpose

Chain 10's `withdrawWell` derives from the same `cappedBalance`, and the template asserts

```
transferFrom-to-ECOSYSTEM_RESERVE + withdrawWell  ~=  stkWellEmissionsPerSecond * duration
```

Today `withdrawWell` is `[]` because the dust falls under the existing 1e15 safety margin, so nothing breaks. If Optimism auction proceeds ever exceed that margin, this assert will compare a non-zero amount against `0` and fail.

I left it alone because gating it would strand auction proceeds in the holder contract instead of recycling them to the ecosystem reserve — an economic decision rather than a mechanical one. The failure mode is loud, not silent.

## Verification

- `npx tsc --noEmit` — the two changed files are clean. Three pre-existing `bigint | undefined` errors in `src/markets.ts` are untouched by this PR.
- No behaviour change while `rewardsEnabled` is `true`: the early return only fires on the wind-down flag.

## Rollout

The deployed worker still emits `373357228`, so the in-flight MIP-X65 (moonwell-contracts-v2#685) keeps that value and is unaffected. The next generated epoch is clean once this deploys.
